### PR TITLE
Update beego dependency v1.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/appleboy/gofight/v2
+module github.com/nickkeers/gofight/v2
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nickkeers/gofight/v2
+module github.com/appleboy/gofight/v2
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	gitea.com/lunny/tango v0.6.1
-	github.com/astaxie/beego v1.11.1
+	github.com/astaxie/beego v1.12.0
 	github.com/gin-gonic/gin v1.4.0
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.2


### PR DESCRIPTION
Update beego to v1.12.0 to remove a dependency error. The child dependency belogik/goes no longer exists, and in v1.12.0 of beego it was replaced with github.com/OwnLocal/goes v1.0.0.

appleboy/gin-jwt will need to be pointed to the version with this fix in for it to work too, see: https://github.com/appleboy/gin-jwt/issues/228