### PR TITLE
Fix request for Echo v4.2.2 RewriteURL middleware

### DIFF
--- a/gofight.go
+++ b/gofight.go
@@ -311,6 +311,7 @@ func (rc *RequestConfig) initTest() (*http.Request, *httptest.ResponseRecorder) 
 	body := bytes.NewBufferString(rc.Body)
 
 	req, _ := http.NewRequest(rc.Method, rc.Path, body)
+	req.RequestURI = req.URL.RequestURI()
 
 	if len(qs) > 0 {
 		req.URL.RawQuery = qs


### PR DESCRIPTION
Echo v4.2.2 URL rewriter use `req.RequestURI` instead of `req.URL.RawPath`
https://github.com/labstack/echo/pull/1802/files